### PR TITLE
Chapter 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 /config/database.yml
+/config/application.yml
 /test/*
 
 config/settings.local.yml

--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -1,0 +1,36 @@
+0---
+include:
+  - "app/**/*.rb"
+  - "config/**/*.rb"
+  - "lib/**/*.rb"
+exclude:
+  - spec/**/*
+  - vendor/**/*
+  - ".bundle/**/*"
+require:
+- actioncable
+- actionmailer
+- actionpack
+- actionview
+- activejob
+- activemodel
+- activerecord
+- activestorage
+- activesupport
+  - activesupport
+domains: []
+reporters:
+  - rubocop
+  - require_not_found
+  - typecheck
+  - update_errors
+formatter:
+  rubocop:
+    cops: safe
+    except: []
+    only: []
+    extra_args: []
+require_paths: []
+plugins:
+  - solargraph-rails
+max_files: 5000

--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,13 @@ ruby "3.2.2"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "bcrypt", "3.1.18"
 gem "bootstrap-sass", "3.4.1"
+gem "bootstrap-will_paginate", "1.0.0"
 gem "config"
+gem "faker", "2.21.0"
 gem "rails", "~> 7.0.5"
 gem "rails-i18n"
 gem "sassc-rails", "2.1.2"
-
+gem "will_paginate", "3.3.1"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
+    bootstrap-will_paginate (1.0.0)
+      will_paginate
     builder (3.2.4)
     capybara (3.39.2)
       addressable
@@ -133,6 +135,8 @@ GEM
       zeitwerk (~> 2.6)
     erubi (1.12.0)
     execjs (2.8.1)
+    faker (2.21.0)
+      i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -290,6 +294,7 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    will_paginate (3.3.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.11)
@@ -301,9 +306,11 @@ DEPENDENCIES
   bcrypt (= 3.1.18)
   bootsnap
   bootstrap-sass (= 3.4.1)
+  bootstrap-will_paginate (= 1.0.0)
   capybara
   config
   debug
+  faker (= 2.21.0)
   importmap-rails
   jbuilder
   mysql2 (~> 0.5)
@@ -321,6 +328,7 @@ DEPENDENCIES
   tzinfo-data
   web-console
   webdrivers
+  will_paginate (= 3.3.1)
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -267,3 +267,15 @@ input {
   width: auto;
   margin-left: 0;
 }
+
+/* Users index */
+
+.users {
+  list-style: none;
+  margin: 0;
+  li {
+    overflow: auto;
+    padding: 10px 0;
+    border-bottom: 1px solid $gray-lighter;
+  }
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,25 +1,51 @@
 class UsersController < ApplicationController
-  def show
-    @user = User.find_by id: params[:id]
-    return if @user
+  before_action :find_user, only: %i(show edit update destroy)
+  before_action :logged_in_user, only: %i(index edit update destroy)
+  before_action :correct_user, only: %i(edit update)
+  before_action :admin_user, only: :destroy
 
-    flash[:error] = t "users.not_found"
-    redirect_to root_path
+  def index
+    @users = User.paginate(page: params[:page])
   end
+
+  def show; end
 
   def new
     @user = User.new
   end
 
   def create
-    @user = User.new(user_params)
+    @user = User.new user_params
     if @user.save
       reset_session
-      log_in @user
-      flash[:success] = t "users.welcome"
+      login @user
+      flash[:success] = t("users.new.success")
       redirect_to @user
     else
+      flash.now[:danger] = t("users.new.error")
       render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @user.update user_params
+      flash[:success] = t("users.edit.success")
+      redirect_to @user
+    else
+      flash[:danger] = t("users.edit.error")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @user.destroy
+      flash[:success] = t("users.edit.delete")
+      redirect_to users_url, status: :see_other
+    else
+      flash[:danger] = t("users.edit.error")
+      redirect_to users_url, status: :unprocessable_entity
     end
   end
 
@@ -27,5 +53,30 @@ class UsersController < ApplicationController
   def user_params
     params.require(:user).permit(:name, :email, :password,
                                  :password_confirmation)
+  end
+
+  # Before filters
+  # Confirms a logged-in user
+  def logged_in_user
+    return if logged_in?
+
+    store_location
+    flash[:danger] = t("users.required_login")
+    redirect_to login_url, status: :see_other
+  end
+
+  def find_user
+    @user = User.find_by id: params[:id]
+    redirect_to root_path, flash: {warning: t(".index.error")} if @user.nil?
+  end
+
+  # Confirms the correct user.
+  def correct_user
+    redirect_to root_path, status: :see_other unless current_user? @user
+  end
+
+  # Confirms an admin user.
+  def admin_user
+    redirect_to root_path, status: :see_other unless current_user.admin?
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,5 +1,5 @@
 module SessionsHelper
-  def log_in user
+  def login user
     session[:user_id] = user.id
     # Guard against session replay attacks.
     # See https://bit.ly/33UvK0w for more.
@@ -13,11 +13,14 @@ module SessionsHelper
   # Returns the current logged-in user (if any).
   def current_user
     if user_id = session[:user_id]
-      @current_user ||= User.find_by(id: user_id) if session[:user_id]
+      user = User.find_by(id: user_id)
+      if user && session[:session_token] == user.session_token
+        @current_user = user
+      end
     elsif user_id = cookies.signed[:user_id]
       user = User.find_by id: user_id
       if user&.authenticated? :remember, cookies[:remember_token]
-        log_in user
+        login user
         @current_user = user
       end
     end
@@ -31,7 +34,7 @@ module SessionsHelper
   end
 
   # Logs out the current user.
-  def log_out
+  def logout
     forget(current_user)
     reset_session
     @current_user = nil
@@ -42,5 +45,10 @@ module SessionsHelper
     user.remember
     cookies.permanent.encrypted[:user_id] = user.id
     cookies.permanent[:remember_token] = user.remember_token
+  end
+
+  # Returns true if the given user is the current user.
+  def current_user? user
+    user && user == current_user
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
     format: {with: Settings.validate.email_regex},
     uniqueness: true
   validates :password, presence: true,
-length: {minimum: Settings.validate.digits.length_6}
+length: {minimum: Settings.validate.digits.length_6}, allow_nil: true
 
   has_secure_password
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,14 +13,14 @@
         <li><%= link_to t("static_pages.home.title"), root_path %></li>
         <li><%= link_to t("static_pages.help.title"), help_path %></li>
         <% if logged_in? %>
-          <li><%= link_to t("layouts.header.users.title"), "#" %></li>
+          <li><%= link_to t("layouts.header.users.title"), users_path %></li>
           <li class="dropdown">
             <a href="#" id="account" class="dropdown-toggle">
               <%= t t("layouts.header.account.title")%> <b class="caret"></b>
             </a>
             <ul id="dropdown-menu" class="dropdown-menu">
               <li><%= link_to t("layouts.header.account.drop_down.profile"), current_user %></li>
-              <li><%= link_to t("layouts.header.account.drop_down.settings"), "#" %></li>
+              <li><%= link_to t("layouts.header.account.drop_down.settings"), edit_user_path(current_user) %></li>
               <li class="divider"></li>
               <li>
                 <%= link_to t("layouts.header.account.drop_down.logout"), logout_path,

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,7 +9,7 @@
      <%= f.password_field :password, class: "form-control" %>
      <%= f.label :remember_me, class: "checkbox inline" do %>
         <%= f.check_box :remember_me %>
-        <span>t "remember_me"</span>
+        <span>t ".remember_me"</span>
       <% end %>
      <%= f.submit "Log in", class: "btn btn-primary" %>
    <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_with(model: @user) do |f| %>
+  <%= render "shared/error_messages" %>
+
+  <%= f.label :name %>
+  <%= f.text_field :name, class: "form-control" %>
+
+  <%= f.label :email %>
+  <%= f.email_field :email, class: "form-control" %>
+
+  <%= f.label :password %>
+  <%= f.password_field :password, class: "form-control" %>
+
+  <%= f.label :password_confirmation, "Confirmation" %>
+  <%= f.password_field :password_confirmation, class: "form-control" %>
+
+  <%= f.submit t ".sign_up", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,0 +1,8 @@
+<li>
+  <%= gravatar_for user, size: 50 %>
+  <%= link_to user.name, user %>
+  <% if current_user.admin? && !current_user?(user) %>
+    | <%= link_to "delete", user, data: { "turbo-method": :delete,
+                                          turbo_confirm: "You sure?" } %>
+  <% end %>
+</li>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,12 @@
+<% provide(:title, "Edit user") %>
+<h1>t "update_profile"</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= render "form" %>
+    <div class="gravatar_edit">
+      <%= gravatar_for @user %>
+      <a href="https://gravatar.com/emails" target="_blank">t "change"</a>
+    </div>
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,11 @@
+<% provide(:title, t(".all_users")) %>
+<h1>t "all_users"</h1>
+<%= will_paginate %>
+
+<ul class="users">
+  <% @users.each do |user| %>
+    <%= render @users %>
+  <% end %>
+</ul>
+
+<%= will_paginate %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,22 +3,6 @@
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
-    <%= form_with(model: @user) do |f| %>
-      <%= render "shared/error_messages" %>
-
-      <%= f.label :name %>
-      <%= f.text_field :name, class: "form-control" %>
-
-      <%= f.label :email %>
-      <%= f.email_field :email, class: "form-control" %>
-
-      <%= f.label :password %>
-      <%= f.password_field :password, class: "form-control" %>
-
-      <%= f.label :password_confirmation, "Confirmation" %>
-      <%= f.password_field :password_confirmation, class: "form-control" %>
-
-      <%= f.submit t "sign_up", class: "btn btn-primary" %>
-    <% end %>
+    <%= render "form" %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,3 +41,7 @@ en:
   sign_up: "Create my account"
   remember_me: "Rememeber me on this computer"
   invalid_email_password_combination: "Invalid email/password"
+  all_user: "All Users"
+  update_profile: "Update your profile"
+  change: "Change"
+  all_users: "All users"

--- a/config/locales/vn.yml
+++ b/config/locales/vn.yml
@@ -39,3 +39,7 @@ vn:
   sign_up: "Tao tai khoan cua toi"
   remember_me: "Ghi nho dang nhap"
   invalid_email_password_combination: "Email/password khong hop le"
+  all_user: "Tat ca nguoi dung"
+  update_profile: "Cap nhat ho so cua ban"
+  change: "Thay doi"
+  all_users: "Tat ca nguoi dung"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,4 +8,5 @@ validate:
     length_50: 50
     length_255: 255
     length_6: 6
+    length_30: 30
   email_regex:  !ruby/regexp /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i

--- a/db/migrate/20230824162451_add_admin_to_users.rb
+++ b/db/migrate/20230824162451_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_23_020015) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_24_162451) do
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -18,6 +18,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_23_020015) do
     t.datetime "updated_at", null: false
     t.string "password_digest"
     t.string "remember_digest"
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,17 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+# Create a main sample user.
+User.create!(name:  "Example User",
+  email: "example@railstutorial.org",
+  password:              "foobar",
+  password_confirmation: "foobar",
+  admin: true)
+
+# Generate a bunch of additional users.
+99.times do |n|
+name  = Faker::Name.name
+email = "example-#{n+1}@railstutorial.org"
+password = "password"
+User.create!(name:  name,
+    email: email,
+    password:              password,
+    password_confirmation: password)
+end

--- a/rails-solagraph.rb
+++ b/rails-solagraph.rb
@@ -1,0 +1,31 @@
+# The following comments fill some of the gaps in Solargraph's understanding of
+# Rails apps. Since they're all in YARD, they get mapped in Solargraph but
+# ignored at runtime.
+#
+# You can put this file anywhere in the project, as long as it gets included in
+# the workspace maps. It's recommended that you keep it in a standalone file
+# instead of pasting it into an existing one.
+#
+# @!parse
+#   class ActionController::Base
+#     include ActionController::MimeResponds
+#     extend ActiveSupport::Callbacks::ClassMethods
+#     extend AbstractController::Callbacks::ClassMethods
+#   end
+#   class ActiveRecord::Base
+#     extend ActiveRecord::QueryMethods
+#     extend ActiveRecord::FinderMethods
+#     extend ActiveRecord::Associations::ClassMethods
+#     extend ActiveRecord::Inheritance::ClassMethods
+#     include ActiveRecord::Persistence
+#   end
+# @!override ActiveRecord::FinderMethods#find
+#   @overload find(id)
+#     @param id [Integer]
+#     @return [self]
+#   @overload find(list)
+#     @param list [Array]
+#     @return [Array<self>]
+#   @overload find(*args)
+#     @return [Array<self>]
+#   @return [self, Array<self>]


### PR DESCRIPTION
1. **allow_nil:** Trong ngữ cảnh của Ruby và Ruby on Rails, `allow_nil` được sử dụng trong khai báo của một mối quan hệ (relationship) giữa các model trong ActiveRecord. Khi bạn sử dụng `allow_nil: true` trong khai báo mối quan hệ, điều này cho phép mối quan hệ đó không bắt buộc phải có giá trị. Ví dụ:

   ```ruby
   class User < ApplicationRecord
     has_many :posts, allow_nil: true
   end
   ```

   Trong trường hợp này, một user có thể không có bất kỳ bài viết nào liên kết.

2. **Cơ chế phân trang:** Cơ chế phân trang được sử dụng để hiển thị một tập hợp lớn dữ liệu thành các trang nhỏ hơn, giúp cải thiện trải nghiệm người dùng và tăng hiệu suất ứng dụng. Trong Ruby on Rails, bạn có thể sử dụng gem như `will_paginate` hoặc `kaminari` để thực hiện phân trang. Cơ chế này thường dựa vào các thông số như số trang, số phần tử trên mỗi trang, và tập dữ liệu ban đầu.

3. **Sử dụng partial và render collection:** Trong Ruby on Rails, partials là các view nhỏ được tái sử dụng để tạo thành các view lớn hơn. `render collection` được sử dụng để hiển thị nhiều đối tượng tương tự trong một partial duy nhất. Điều này giúp giảm lặp lại mã trong view và tạo ra sự linh hoạt trong cách bạn hiển thị dữ liệu.

4. **So sánh render và redirect_to:**
   - `render`: Sử dụng để hiển thị một view mà không thay đổi URL trình duyệt. Nó thường được sử dụng để hiển thị lại trang khi có lỗi xảy ra hoặc để hiển thị kết quả xử lý mẫu form.
   - `redirect_to`: Sử dụng để chuyển hướng người dùng đến một URL mới. Khi sử dụng `redirect_to`, trình duyệt sẽ thực hiện yêu cầu mới đến URL đích, trong khi `render` chỉ làm thay đổi nội dung trang hiện tại mà không thay đổi URL.
   -
![image](https://github.com/Huy0110/sample-app/assets/94180098/1563e20e-c531-4342-83d7-b9d9fd155ede)

